### PR TITLE
1.26アプデ対応

### DIFF
--- a/src/P-Checker-asm/BlockContoroller.cs
+++ b/src/P-Checker-asm/BlockContoroller.cs
@@ -81,6 +81,9 @@ namespace PCheckerSpace
                 },
                 {
                     (int)BlockType.LogicGate, typeof(LogicGateScript)
+                },
+                {
+                    (int)BlockType.Speedometer, typeof(SpeedometerScript)
                 }
             };
 
@@ -365,8 +368,8 @@ namespace PCheckerSpace
         public class TimerScript : CustomBlockBehaviour
         {
             private TimerBlock TB;
-            private float[] Wait = new float[2] { 0f, 60f };
-            private float[] Duration = new float[2] { 0f, 60f };
+            private float[] Wait = new float[2] { 0f, 999999.99f };
+            private float[] Duration = new float[2] { 0f, 999999.99f };
             public override void SafeAwake()
             {
                 TB = GetComponent<TimerBlock>();
@@ -455,6 +458,20 @@ namespace PCheckerSpace
             public override void BuildingUpdate()
             {
                 powerFlag = LG.ModeMenu.Value == EdgeDetector;
+            }
+        }
+        public class SpeedometerScript : CustomBlockBehaviour
+        {
+            private SpeedometerBlock SB; //BlockBehaviourÇÊÇËåpè≥
+            private float minValue = -99999f;
+            private float maxValue = 999999.99f;
+            public override void SafeAwake()
+            {
+                SB = GetComponent<SpeedometerBlock>();
+            }
+            public override void BuildingUpdate()
+            {
+                powerFlag = SB.HeightSlider.Value > maxValue || SB.HeightSlider.Value < minValue;
             }
         }
     }

--- a/src/P-Checker-asm/BlockContoroller.cs
+++ b/src/P-Checker-asm/BlockContoroller.cs
@@ -78,6 +78,9 @@ namespace PCheckerSpace
                 },
                 {
                     (int)BlockType.Suspension, typeof(SuspensionScript)
+                },
+                {
+                    (int)BlockType.LogicGate, typeof(LogicGateScript)
                 }
             };
 
@@ -439,6 +442,19 @@ namespace PCheckerSpace
                     (CMCH.AccelerationSlider.Max < CMCH.AccelerationSlider.Value && CMCH.AccelerationSlider.Value < float.PositiveInfinity)) ||
                     // スピニングブロックの自動ブレーキ = LimitSpeedToMotor
                     CMCH.AutoBreakToggle.IsActive == false;
+            }
+        }
+        public class LogicGateScript : CustomBlockBehaviour
+        {
+            private LogicGate LG;
+            private int EdgeDetector = 11; //エッジ検出のモード番号
+            public override void SafeAwake()
+            {
+                LG = GetComponent<LogicGate>();
+            }
+            public override void BuildingUpdate()
+            {
+                powerFlag = LG.ModeMenu.Value == EdgeDetector;
             }
         }
     }

--- a/src/P-Checker-asm/BlockContoroller.cs
+++ b/src/P-Checker-asm/BlockContoroller.cs
@@ -65,7 +65,7 @@ namespace PCheckerSpace
                     (int)BlockType.CircularSaw, typeof(WheelScript)
                 },
                 {
-                    (int)BlockType.SpinningBlock, typeof(WheelScript)
+                    (int)BlockType.SpinningBlock, typeof(SpinningBlockScript)
                 },
                 {
                     (int)BlockType.CogMediumPowered, typeof(WheelScript)
@@ -412,6 +412,33 @@ namespace PCheckerSpace
 
                     // max < acc < +inf
                     (CMCH.AccelerationSlider.Max < CMCH.AccelerationSlider.Value && CMCH.AccelerationSlider.Value < float.PositiveInfinity));
+            }
+        }
+        public class SpinningBlockScript : CustomBlockBehaviour
+        {
+            private CogMotorControllerHinge CMCH;
+            private float[] Speed           = new float[2] { 0f, 2f };
+            private float[] Acceleration    = new float[2] { 0.1f, 50f };
+            public override void SafeAwake()
+            {
+                CMCH = GetComponent<CogMotorControllerHinge>();
+            }
+            public override void BuildingUpdate()
+            {
+                powerFlag =
+                    // speed < min
+                    (CMCH.SpeedSlider.Value < CMCH.speedSlider.Min ||
+
+                    // max < speed
+                    CMCH.speedSlider.Max < CMCH.SpeedSlider.Value) ||
+
+                    // acc < min
+                    (CMCH.AccelerationSlider.Value < CMCH.AccelerationSlider.Min ||
+
+                    // max < acc < +inf
+                    (CMCH.AccelerationSlider.Max < CMCH.AccelerationSlider.Value && CMCH.AccelerationSlider.Value < float.PositiveInfinity)) ||
+                    // スピニングブロックの自動ブレーキ = LimitSpeedToMotor
+                    CMCH.AutoBreakToggle.IsActive == false;
             }
         }
     }


### PR DESCRIPTION
アプデ対応
・スピブロの無動力化禁止
・ロジゲのエッジ検出禁止
修正点
・オートメーション系ブロックの上下限が間違えていたので修正(直接入力で999999まで入力できる)
・速度計の限凸判定を追加

P1GPのバージョン別に変えるみたいなのは入れてないです。
利便性の問題から、第７回大会が終わった後はスピブロとロジゲの禁止設定は消して良いと思います。
(それで言うと第n回当時無かったブロックを検出してみたいな面倒な事になりそうなので)
